### PR TITLE
Fix: Obelisk TimestampPrecision as string

### DIFF
--- a/src/obelisk/asynchronous/producer.py
+++ b/src/obelisk/asynchronous/producer.py
@@ -41,7 +41,7 @@ class Producer(Client):
 
         params = {
             'datasetId': dataset,
-            'timestampPrecision': precision,
+            'timestampPrecision': precision.value,
             'mode': mode.value
         }
 


### PR DESCRIPTION
When passing a TimestampPrecision object into the params, the full name of the enum gets encoded into
TimestampPrecision.MILLISECONDS e.g.

Obelisk understandably throws a fit and desires no prefixes. We missed a `.value` call, added back here.