### PR TITLE
Add support for integer type in CORE

### DIFF
--- a/src/obelisk/asynchronous/core.py
+++ b/src/obelisk/asynchronous/core.py
@@ -42,7 +42,7 @@ from obelisk.types import ObeliskKind
 from obelisk.types.core import IngestMode
 
 
-DataType = Literal["number", "number[]", "json", "bool", "string"]
+DataType = Literal["number", "number[]", "json", "bool", "string", "integer", "integer[]"]
 """The possible types of data Obelisk can accept"""
 
 
@@ -112,6 +112,15 @@ class IncomingDatapoint(BaseModel):
             or any([not isinstance(x, Number) for x in self.value])
         ):
             raise ValueError("Type suffix mismatch, expected value of number[]")
+
+        if suffix == "integer" and not isinstance(self.value, int):
+            raise ValueError("Type suffix mismatch, expected value of type integer")
+
+        if suffix == "integer[]" and (
+            type(self.value) is not list
+            or any([not isinstance(x, int) for x in self.value])
+        ):
+            raise ValueError("Type suffix mismatch, expected value of integer[]")
 
         # Do not check json, most things should be serialisable
 


### PR DESCRIPTION
Obelisk CORE version 2.3.0 added support for `integer` and `integer[]`, with `number` variants remaining as a float-or-integer supertype.

Usage of these types affords more compact storage and faster querying